### PR TITLE
ci: add preview URL comment to PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -77,18 +81,18 @@ jobs:
           script: |
             const previewUrl = '${{ steps.deploy.outputs.preview_url }}';
             const body = `## 🚀 Preview Deployment Ready!\n\n**Preview URL:** ${previewUrl}\n\n*This preview was automatically deployed by GitHub Actions.*`;
-            
+
             // Find existing comment
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            
+
             const botComment = comments.find(comment => 
               comment.body.includes('Preview Deployment Ready')
             );
-            
+
             if (botComment) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,


### PR DESCRIPTION
Adds automatic comment with preview deployment URL when PR is created/updated.

## Changes
- Capture preview deployment URL from Vercel
- Post comment to PR with clickable preview link
- Update existing comment if PR is updated (no spam)